### PR TITLE
Rework to return null for no-name, and error on invalid input

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -22,4 +22,5 @@
     "describe": false
   , "it": false
   }
+, "evil": true
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-  - 0.12
+  - "0.12"
+  - "iojs"
+  - "iojs-v1.0.4"

--- a/index.js
+++ b/index.js
@@ -3,8 +3,9 @@
 var toString = Object.prototype.toString
 
 module.exports = function(fn) {
-  if (toString.call(fn) !== '[object Function]') return null
+  if (toString.call(fn) !== '[object Function]')
+      throw Error('Attempted to get name of non-function')
   if (fn.name) return fn.name
   var name = /^\s*function\s*([^\(]*)/im.exec(fn.toString())[1]
-  return name || 'anonymous'
+  return name || null
 }

--- a/package.json
+++ b/package.json
@@ -1,25 +1,27 @@
 {
-  "name": "get-function-name"
-, "author": "Beau Sorensen <mail@beausorensen.com> (http://github.com/sorensen)"
-, "version": "0.0.1"
-, "license": "MIT"
-, "keywords": [
-    "function", "name"
-  ]
-, "description": "Get name of a function"
-, "repository": {
-    "type": "git"
-  , "url": "git://github.com/sorensen/get-function-name.js.git"
-  }
-, "engines": {
+  "name": "get-function-name",
+  "author": "Beau Sorensen <mail@beausorensen.com> (http://github.com/sorensen)",
+  "version": "0.0.1",
+  "license": "MIT",
+  "keywords": [
+    "function",
+    "name"
+  ],
+  "description": "Get name of a function",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/sorensen/get-function-name.js.git"
+  },
+  "engines": {
     "node": "0.x"
-  }
-, "main": "index.js"
-, "scripts": {
-    "test": "npm run hint && ./node_modules/mocha/bin/mocha -R spec test.js"
-  , "hint": "jshint *.js *.json"
-  }
-, "devDependencies": {
+  },
+  "main": "index.js",
+  "scripts": {
+    "test": "npm run hint && ./node_modules/mocha/bin/mocha -R spec test.js",
+    "hint": "jshint *.js *.json"
+  },
+  "devDependencies": {
+    "jshint": "^2.8.0",
     "mocha": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "get-function-name",
   "author": "Beau Sorensen <mail@beausorensen.com> (http://github.com/sorensen)",
+  "contributors": [
+      "An <an@cyan.io>"
+  ],
   "version": "0.0.1",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "npm run hint && ./node_modules/mocha/bin/mocha -R spec test.js",
+    "test": "./node_modules/mocha/bin/mocha -R spec test.js",
     "hint": "jshint *.js *.json"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha -R spec test.js",
+    "test": "mocha -R spec test.js",
     "hint": "jshint *.js *.json"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ var getFunctionName = require('get-function-name')
 var foo = function() {}
 function bar() {}
 
-getFunctionName(foo) // 'anonymous'
+getFunctionName(foo) // null
 getFunctionName(bar) // 'bar'
-getFunctionName('hello') // null
+getFunctionName('hello') // throws error
 ```

--- a/test.js
+++ b/test.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var type = require('./index')
-  , assert = require('assert')
+var assert = require('assert')
   , ase = assert.strictEqual
  
 it('get-function-name', function() {

--- a/test.js
+++ b/test.js
@@ -15,7 +15,7 @@ it('get-function-name', function() {
   ase(getName(new Function('a', 'b', 'return')), 'anonymous')
 
   function Klass() {}
-  klass = new Klass()
+  var klass = new Klass()
   ase(getName(klass.constructor), 'Klass')
  
   ase(getName(true), null)

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@
 
 var assert = require('assert')
   , ase = assert.strictEqual
+  , asthrows = assert.throws
  
 it('get-function-name', function() {
   var getName = require('./index')
@@ -9,19 +10,18 @@ it('get-function-name', function() {
   ase(getName(function foo() {}), 'foo')
   ase(getName(function foo(){}), 'foo')
   ase(getName(function foo  (){}), 'foo')
-  
-  ase(getName(function () {}), 'anonymous')
-  ase(getName(new Function('a', 'b', 'return')), 'anonymous')
+
+  ase(getName(function () {}), null)
+  ase(getName(new Function('a', 'b', 'return')), "anonymous")
 
   function Klass() {}
   var klass = new Klass()
   ase(getName(klass.constructor), 'Klass')
- 
-  ase(getName(true), null)
-  ase(getName(), null)
-  ase(getName(''), null)
-  ase(getName([1, 2]), null)
-  ase(getName({a: 3}), null)
+
+  ;[ true, undefined, null, "", [1,2], {a:3} ]
+    .forEach(function(x) {
+      asthrows(function() { return getName(x); })
+    })
 
   ase(getName(String), 'String')
   ase(getName(Number), 'Number')


### PR DESCRIPTION
Passing a non-function into something that gives you the name of a function is clearly a user error and should be treated as such.

Returning null for functions that don't have a name makes more sense than the previous mapping to "anonymous":  You can have a function with a name "anonymous", which that could be confused with.

Some other fixes too while I was in there—see commit messages.

Bump to v1?
